### PR TITLE
#24 on remove check if the chart was destroyed

### DIFF
--- a/src/data/column/column.js
+++ b/src/data/column/column.js
@@ -44,7 +44,10 @@ can.Component.extend({
 			this.viewModel.updateColumn();
 		},
 		removed: function() {
-			this.viewModel.unloadColumn();
+			// check if the chart was not destroyed:
+			if (this.element.parent().scope().attr('chart')){
+				this.viewModel.unloadColumn();
+			}
 		},
 		"{viewModel} valueSerialized": function() {
 			this.viewModel.updateColumn();

--- a/src/data/data.js
+++ b/src/data/data.js
@@ -46,6 +46,11 @@ can.Component.extend({
 		"{viewModel} change": function(viewModel, ev, attr, type, newVal, oldVal) {
 			// console.log(attr, 'from', oldVal, 'to', newVal);
 			this.viewModel.loadAttributeOnChart(attr);
+		},
+		removed: function(){
+			// This component could be removed only if the chart was destroyed.
+			// Clean up `chart` property to let the child components know that the chart was destroyed:
+			this.viewModel.removeAttr('chart');
 		}
 	}
 });

--- a/test/bit-c3_test.js
+++ b/test/bit-c3_test.js
@@ -279,3 +279,22 @@ test('randomString generates a correct length string', () => {
 	var stringLength = 50;
 	equal(randomString(stringLength).length, stringLength);
 });
+
+
+QUnit.module('Template tests (slow)');
+
+test('Should remove chart from DOM correctly', 1, (assert) => {
+	let tpl = '{{#if isVisible}}<bit-c3><bit-c3-data><bit-c3-data-column/></bit-c3-data></bit-c3>{{/if}}',
+		vm = new (can.Map.extend({
+			define: {isVisible: {value: true}}
+		}))(),
+		frag = can.stache(tpl)(vm);
+
+	// We need to render the fragment because test requires the "inserted" event of the components being called:
+	$('#qunit-fixture').append(frag);
+
+	vm.attr('isVisible', false);
+
+	// The test will fail if removing the chart from DOM causes a JS exception.
+	assert.ok(true, 'Chart was correctly removed');
+});


### PR DESCRIPTION
on remove event cleanup chart property on bit-c3-data and check for it in bit-c3-data-column before calling unloadColumn.