### PR TITLE
Move CanJS from dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,12 +18,12 @@
     "prepublish": "./node_modules/.bin/grunt build"
   },
   "dependencies": {
-    "can": "^2.2.5",
     "cssify": "0.6.0",
     "d3": "<=3.5.0",
     "c3": "0.4.10"
   },
   "devDependencies": {
+    "can": "^2.2.5",
     "documentjs": "git://github.com/bitovi/documentjs#master",
     "funcunit": "^3.0.0",
     "grunt": "~0.4.4",


### PR DESCRIPTION
This allows bit-c3 to be used in later versions of CanJS (like 2.3).