### PR TITLE
Upgrade to d3 3.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "cssify": "0.6.0",
-    "d3": "<=3.5.0",
+    "d3": "^3.5.17",
     "c3": "0.4.10"
   },
   "devDependencies": {


### PR DESCRIPTION
This prevents the unneeded jsdom dependency. Closes #30