### PR TITLE
Allow full config

### DIFF
--- a/examples/chart/bar-x-labels-rotated.html
+++ b/examples/chart/bar-x-labels-rotated.html
@@ -6,7 +6,7 @@
 		<!-- Template to load -->
 		<script type="text/stache" id="demo-html" can-autorender>
 <can-import from="bit-c3" />
-<bit-c3 {axis}="axisConfig">
+<bit-c3 {config}="config">
 	<bit-c3-data type="{type}">
 		{{#each dataColumns}}
 			<bit-c3-data-column value="{.}" {axis-x}="axisXData" />
@@ -24,34 +24,31 @@
 import DefineList from "can-define/list/list";
 import DefineMap from "can-define/map/map";
 import canViewModel from "can-view-model";
-import domData from "can-util/dom/data/data";
 
 let data1 = new DefineList(['data1', 30, 200, 100, 400, 150, 250]),
 		data2 = new DefineList(['data2', 130, 100, 140, 200, 150, 50]),
 		type = 'bar',
-		axisConfig = {
-			x: {
-				type: 'category',
-				tick: {
-					rotate: -45,
-					multiline: false
-				},
-				height: 130
+		config = {
+			axis: {
+				x: {
+					type: 'category',
+					tick: {
+						rotate: -45,
+						multiline: false
+					},
+					height: 130
+				}
 			}
 		},
 		axisXData = new DefineList(['x','cat 1','cat 2','cat 3','cat 4','cat 5','cat 6']);
 
 var element = document.getElementById("demo-html");
-var vm = new (DefineMap.extend({seal: false}, {
-		axisX: {type: '*'}
-	}))({
-		dataColumns: new DefineList([data1, data2]),
-		type,
-	  axisConfig,
-		axisXData
-	});
-window.vm = vm;
-domData.set.call(element, "viewModel", vm);
+canViewModel(element).set({
+	dataColumns: new DefineList([data1, data2]),
+	type,
+	config,
+	axisXData
+});
 		</script>
 	</body>
 </html>

--- a/examples/chart/bar-x-labels-rotated.html
+++ b/examples/chart/bar-x-labels-rotated.html
@@ -1,55 +1,55 @@
 <html>
-	<head>
-		<title>Bar Chart</title>
-	</head>
-	<body>
-		<!-- Template to load -->
-		<script type="text/stache" id="demo-html" can-autorender>
+  <head>
+    <title>Bar Chart</title>
+  </head>
+  <body>
+    <!-- Template to load -->
+    <script type="text/stache" id="demo-html" can-autorender>
 <can-import from="bit-c3" />
 <bit-c3 {config}="config">
-	<bit-c3-data type="{type}">
-		{{#each dataColumns}}
-			<bit-c3-data-column value="{.}" {axis-x}="axisXData" />
-		{{/each}}
-	</bit-c3-data>
+  <bit-c3-data type="{type}">
+    {{#each dataColumns}}
+      <bit-c3-data-column value="{.}" {axis-x}="axisXData" />
+    {{/each}}
+  </bit-c3-data>
 </bit-c3>
-		</script>
+    </script>
 
 <!-- TODO add support for 
-	<c3-bar width-ratio="0.5" width="100" />
+  <c3-bar width-ratio="0.5" width="100" />
 -->
 
-		<!-- Loading Script -->
-		<script src="../../node_modules/steal/steal.js" id="demo-source" main="can-view-autorender">
+    <!-- Loading Script -->
+    <script src="../../node_modules/steal/steal.js" id="demo-source" main="can-view-autorender">
 import DefineList from "can-define/list/list";
 import DefineMap from "can-define/map/map";
 import canViewModel from "can-view-model";
 
 let data1 = new DefineList(['data1', 30, 200, 100, 400, 150, 250]),
-		data2 = new DefineList(['data2', 130, 100, 140, 200, 150, 50]),
-		type = 'bar',
-		config = {
-			axis: {
-				x: {
-					type: 'category',
-					tick: {
-						rotate: -45,
-						multiline: false
-					},
-					height: 130
-				}
-			}
-		},
-		axisXData = new DefineList(['x','cat 1','cat 2','cat 3','cat 4','cat 5','cat 6']);
+    data2 = new DefineList(['data2', 130, 100, 140, 200, 150, 50]),
+    type = 'bar',
+    config = {
+      axis: {
+        x: {
+          type: 'category',
+          tick: {
+            rotate: -45,
+            multiline: false
+          },
+          height: 130
+        }
+      }
+    },
+    axisXData = new DefineList(['x','cat 1','cat 2','cat 3','cat 4','cat 5','cat 6']);
 
 var element = document.getElementById("demo-html");
 canViewModel(element).set({
-	dataColumns: new DefineList([data1, data2]),
-	type,
-	config,
-	axisXData
+  dataColumns: new DefineList([data1, data2]),
+  type,
+  config,
+  axisXData
 });
-		</script>
-	</body>
+    </script>
+  </body>
 </html>
-	
+  

--- a/examples/chart/bar-x-labels-rotated.html
+++ b/examples/chart/bar-x-labels-rotated.html
@@ -1,56 +1,58 @@
 <html>
-  <head>
-    <title>Bar Chart</title>
-  </head>
-  <body>
-    <!-- Template to load -->
-    <script type="text/stache" id="demo-html" can-autorender>
+	<head>
+		<title>Bar Chart</title>
+	</head>
+	<body>
+		<!-- Template to load -->
+		<script type="text/stache" id="demo-html" can-autorender>
 <can-import from="bit-c3" />
-<bit-c3 {axis-x}="axisX">
-  <bit-c3-data type="{type}">
-    {{#each dataColumns}}
-      <bit-c3-data-column value="{.}" {axis-x}="axisXData" />
-    {{/each}}
-  </bit-c3-data>
+<bit-c3 {axis}="axisConfig">
+	<bit-c3-data type="{type}">
+		{{#each dataColumns}}
+			<bit-c3-data-column value="{.}" {axis-x}="axisXData" />
+		{{/each}}
+	</bit-c3-data>
 </bit-c3>
-    </script>
+		</script>
 
 <!-- TODO add support for 
-  <c3-bar width-ratio="0.5" width="100" />
+	<c3-bar width-ratio="0.5" width="100" />
 -->
 
-    <!-- Loading Script -->
-    <script src="../../node_modules/steal/steal.js" id="demo-source" main="can-view-autorender">
+		<!-- Loading Script -->
+		<script src="../../node_modules/steal/steal.js" id="demo-source" main="can-view-autorender">
 import DefineList from "can-define/list/list";
 import DefineMap from "can-define/map/map";
 import canViewModel from "can-view-model";
 import domData from "can-util/dom/data/data";
 
 let data1 = new DefineList(['data1', 30, 200, 100, 400, 150, 250]),
-    data2 = new DefineList(['data2', 130, 100, 140, 200, 150, 50]),
-    type = 'bar',
-    axisX = {
-      type: 'category',
-      tick: {
-        rotate: -45,
-        multiline: false
-      },
-      height: 130
-    },
-    axisXData = new DefineList(['x','cat 1','cat 2','cat 3','cat 4','cat 5','cat 6']);
+		data2 = new DefineList(['data2', 130, 100, 140, 200, 150, 50]),
+		type = 'bar',
+		axisConfig = {
+			x: {
+				type: 'category',
+				tick: {
+					rotate: -45,
+					multiline: false
+				},
+				height: 130
+			}
+		},
+		axisXData = new DefineList(['x','cat 1','cat 2','cat 3','cat 4','cat 5','cat 6']);
 
 var element = document.getElementById("demo-html");
 var vm = new (DefineMap.extend({seal: false}, {
-    axisX: {type: '*'}
-  }))({
-    dataColumns: new DefineList([data1, data2]),
-    type,
-    axisX,
-    axisXData
-  });
+		axisX: {type: '*'}
+	}))({
+		dataColumns: new DefineList([data1, data2]),
+		type,
+	  axisConfig,
+		axisXData
+	});
 window.vm = vm;
 domData.set.call(element, "viewModel", vm);
-    </script>
-  </body>
+		</script>
+	</body>
 </html>
-  
+	

--- a/examples/chart/bar-x-labels-rotated.html
+++ b/examples/chart/bar-x-labels-rotated.html
@@ -1,0 +1,56 @@
+<html>
+  <head>
+    <title>Bar Chart</title>
+  </head>
+  <body>
+    <!-- Template to load -->
+    <script type="text/stache" id="demo-html" can-autorender>
+<can-import from="bit-c3" />
+<bit-c3 {axis-x}="axisX">
+  <bit-c3-data type="{type}">
+    {{#each dataColumns}}
+      <bit-c3-data-column value="{.}" {axis-x}="axisXData" />
+    {{/each}}
+  </bit-c3-data>
+</bit-c3>
+    </script>
+
+<!-- TODO add support for 
+  <c3-bar width-ratio="0.5" width="100" />
+-->
+
+    <!-- Loading Script -->
+    <script src="../../node_modules/steal/steal.js" id="demo-source" main="can-view-autorender">
+import DefineList from "can-define/list/list";
+import DefineMap from "can-define/map/map";
+import canViewModel from "can-view-model";
+import domData from "can-util/dom/data/data";
+
+let data1 = new DefineList(['data1', 30, 200, 100, 400, 150, 250]),
+    data2 = new DefineList(['data2', 130, 100, 140, 200, 150, 50]),
+    type = 'bar',
+    axisX = {
+      type: 'category',
+      tick: {
+        rotate: -45,
+        multiline: false
+      },
+      height: 130
+    },
+    axisXData = new DefineList(['x','cat 1','cat 2','cat 3','cat 4','cat 5','cat 6']);
+
+var element = document.getElementById("demo-html");
+var vm = new (DefineMap.extend({seal: false}, {
+    axisX: {type: '*'}
+  }))({
+    dataColumns: new DefineList([data1, data2]),
+    type,
+    axisX,
+    axisXData
+  });
+window.vm = vm;
+domData.set.call(element, "viewModel", vm);
+    </script>
+  </body>
+</html>
+  

--- a/examples/chart/bar-x-labels.html
+++ b/examples/chart/bar-x-labels.html
@@ -6,7 +6,7 @@
     <!-- Template to load -->
     <script type="text/stache" id="demo-html" can-autorender>
 <can-import from="bit-c3" />
-<bit-c3 axis-x-type="category">
+<bit-c3 {config}="config">
   <bit-c3-data type="{type}">
     {{#each dataColumns}}
       <bit-c3-data-column value="{.}" {axis-x}="axisX" />
@@ -24,21 +24,20 @@
 import DefineList from "can-define/list/list";
 import DefineMap from "can-define/map/map";
 import canViewModel from "can-view-model";
-import domData from "can-util/dom/data/data";
 
 let data1 = new DefineList(['data1', 30, 200, 100, 400, 150, 250]),
     data2 = new DefineList(['data2', 130, 100, 140, 200, 150, 50]),
     type = 'bar',
+    config = { axis: { x: { type: 'category' } } },
     axisX = new DefineList(['x','cat 1','cat 2','cat 3']);
 
-var element = document.getElementById("demo-html");
-var vm = new DefineMap({
-  dataColumns: new DefineList([data1, data2]),
-  type,
-  axisX
+let element = document.getElementById("demo-html");
+canViewModel(element).set({
+	dataColumns: new DefineList([data1, data2]),
+	type,
+	axisX,
+	config
 });
-window.vm = vm;
-domData.set.call(element, "viewModel", vm);
     </script>
   </body>
 </html>

--- a/examples/chart/bar-x-labels.html
+++ b/examples/chart/bar-x-labels.html
@@ -1,0 +1,45 @@
+<html>
+  <head>
+    <title>Bar Chart</title>
+  </head>
+  <body>
+    <!-- Template to load -->
+    <script type="text/stache" id="demo-html" can-autorender>
+<can-import from="bit-c3" />
+<bit-c3 axis-x-type="category">
+  <bit-c3-data type="{type}">
+    {{#each dataColumns}}
+      <bit-c3-data-column value="{.}" {axis-x}="axisX" />
+    {{/each}}
+  </bit-c3-data>
+</bit-c3>
+    </script>
+
+<!-- TODO add support for 
+  <c3-bar width-ratio="0.5" width="100" />
+-->
+
+    <!-- Loading Script -->
+    <script src="../../node_modules/steal/steal.js" id="demo-source" main="can-view-autorender">
+import DefineList from "can-define/list/list";
+import DefineMap from "can-define/map/map";
+import canViewModel from "can-view-model";
+import domData from "can-util/dom/data/data";
+
+let data1 = new DefineList(['data1', 30, 200, 100, 400, 150, 250]),
+    data2 = new DefineList(['data2', 130, 100, 140, 200, 150, 50]),
+    type = 'bar',
+    axisX = new DefineList(['x','cat 1','cat 2','cat 3']);
+
+var element = document.getElementById("demo-html");
+var vm = new DefineMap({
+  dataColumns: new DefineList([data1, data2]),
+  type,
+  axisX
+});
+window.vm = vm;
+domData.set.call(element, "viewModel", vm);
+    </script>
+  </body>
+</html>
+  

--- a/examples/chart/bar-x-labels.html
+++ b/examples/chart/bar-x-labels.html
@@ -33,10 +33,10 @@ let data1 = new DefineList(['data1', 30, 200, 100, 400, 150, 250]),
 
 let element = document.getElementById("demo-html");
 canViewModel(element).set({
-	dataColumns: new DefineList([data1, data2]),
-	type,
-	axisX,
-	config
+  dataColumns: new DefineList([data1, data2]),
+  type,
+  axisX,
+  config
 });
     </script>
   </body>

--- a/src/chart.js
+++ b/src/chart.js
@@ -22,6 +22,8 @@ import ChartVM from './viewmodel';
  *
  * ```html
  * <bit-c3></bit-c3>
+ *
+ * <bit-c3 axis-x-type="category"></bit-c3>
  * ```
  */
 Component.extend({
@@ -31,14 +33,25 @@ Component.extend({
     events: {
         inserted: function(viewModel, ev) {
             var rootElement = ev.target,
-                graphBaseElement = d3.select(rootElement.getElementsByClassName('chart-container')[0]),
-                chart = c3.generate({
-                    bindto: graphBaseElement,
-                    data: {
-                        columns: []
+              graphBaseElement = d3.select(rootElement.getElementsByClassName('chart-container')[0]),
+              axisXType = this.viewModel.attr('axisXType'),
+              config = {
+                  bindto: graphBaseElement,
+                  data: {
+                      columns: []
+                  }
+              };
+
+            if (axisXType){
+                config.data.x = 'x';
+                config.axis = {
+                    x: {
+                        type: axisXType
                     }
-                });
-            this.viewModel.chart = chart;
+                }
+            }
+
+            this.viewModel.chart = c3.generate(config);
         },
         removed: function() {
             if (this.viewModel.chart){

--- a/src/chart.js
+++ b/src/chart.js
@@ -32,29 +32,15 @@ Component.extend({
     viewModel: ChartVM,
     events: {
         inserted: function(viewModel, ev) {
-            var rootElement = ev.target,
-              graphBaseElement = d3.select(rootElement.getElementsByClassName('chart-container')[0]),
-              axisXType = this.viewModel.attr('axisXType'),
-              config = {
-                  bindto: graphBaseElement,
-                  data: {
-                      columns: []
-                  }
-              };
+            let rootElement = ev.target;
 
-            if (axisXType){
-                config.data.x = 'x';
-                config.axis = {
-                    x: {
-                        type: axisXType
-                    }
-                }
-            }
+            this.viewModel.graphBaseElement = d3.select(rootElement.getElementsByClassName('chart-container')[0]);
 
-            this.viewModel.chart = c3.generate(config);
+            this.viewModel.chart = c3.generate(this.viewModel.config);
         },
         removed: function() {
             if (this.viewModel.chart){
+                this.viewModel.graphBaseElement = undefined;
                 this.viewModel.chart = this.viewModel.chart.destroy();
             }
         }

--- a/src/data/column/column.js
+++ b/src/data/column/column.js
@@ -35,6 +35,15 @@ import canViewModel from 'can-view-model';
  *   </bit-c3-data>
  * </bit-c3>
  * ```
+ *
+ * With axis-x (`axis-x-type` must be defined fir `bit-c3`):
+ * ```html
+ * <bit-c3>
+ *   <bit-c3-data>
+ *     <bit-c3-data-column key="dataSet1" value="[1, 2, 3]" axis-x="['x','cat 1','cat 2','cat 3']" />
+ *   </bit-c3-data>
+ * </bit-c3>
+ * ```
  */
 Component.extend({
 	tag: "bit-c3-data-column",

--- a/src/data/column/column.js
+++ b/src/data/column/column.js
@@ -36,9 +36,9 @@ import canViewModel from 'can-view-model';
  * </bit-c3>
  * ```
  *
- * With axis-x (`axis-x-type` must be defined fir `bit-c3`):
+ * With axis-x (`axis-x-type` must be defined for `bit-c3`):
  * ```html
- * <bit-c3>
+ * <bit-c3 axis-x-type="category">
  *   <bit-c3-data>
  *     <bit-c3-data-column key="dataSet1" value="[1, 2, 3]" axis-x="['x','cat 1','cat 2','cat 3']" />
  *   </bit-c3-data>

--- a/src/data/column/column.js
+++ b/src/data/column/column.js
@@ -36,9 +36,14 @@ import canViewModel from 'can-view-model';
  * </bit-c3>
  * ```
  *
- * With axis-x (`axis-x-type` must be defined for `bit-c3`):
+ * With config:
+ * ```js
+ * let vm = {
+ *   config: {axis: {x: {type: 'category'}}}
+ * }
+ * ```
  * ```html
- * <bit-c3 axis-x-type="category">
+ * <bit-c3 {config}="config">
  *   <bit-c3-data>
  *     <bit-c3-data-column key="dataSet1" value="[1, 2, 3]" axis-x="['x','cat 1','cat 2','cat 3']" />
  *   </bit-c3-data>

--- a/src/data/column/viewmodel.js
+++ b/src/data/column/viewmodel.js
@@ -24,10 +24,15 @@ export default DefineMap.extend({seal: false}, {
 		var value = this.dequeueKey(this.value),
 			key = this.key,
 			chart = this.chart,
-			pushing = [key].concat(value);
+			pushing = [key].concat(value),
+			columns = [pushing];
+
+		if (this.attr('axisX')){
+			columns.unshift(this.attr('axisX').attr());
+		}
 		if(value && value.length) {
 			chart.load({
-				columns: [pushing]
+				columns: columns
 			});
 		} else {
 			this.unloadColumn();

--- a/src/data/column/viewmodel.js
+++ b/src/data/column/viewmodel.js
@@ -27,8 +27,8 @@ export default DefineMap.extend({seal: false}, {
 			pushing = [key].concat(value),
 			columns = [pushing];
 
-		if (this.attr('axisX')){
-			columns.unshift(this.attr('axisX').attr());
+		if (this.axisX){
+			columns.unshift(this.axisX.get());
 		}
 		if(value && value.length) {
 			chart.load({

--- a/src/viewmodel.js
+++ b/src/viewmodel.js
@@ -15,6 +15,12 @@ export default DefineMap.extend({
 	 */
 	axisXType: 'string',
 	/**
+	 * Full config for x-axis.
+	 */
+	axisX: {
+		type: '*'
+	},
+	/**
 	 * Config object that c3 chart will be generated with.
 	 */
 	config: {
@@ -32,6 +38,12 @@ export default DefineMap.extend({
 						type: this.axisXType
 					}
 				}
+			}
+			if (this.axisX) {
+				config.data.x = 'x';
+				config.axis = {
+					x: this.axisX
+				};
 			}
 			return config;
 		}

--- a/src/viewmodel.js
+++ b/src/viewmodel.js
@@ -11,37 +11,18 @@ export default DefineMap.extend({
 		type: '*'
 	},
 	/**
-	 * Full config for axis.
-	 */
-	axis: {
-		type: '*'
-	},
-	/**
-	 * Config param for x-axis type.
-	 */
-	axisXType: 'string',
-	/**
 	 * Config object that c3 chart will be generated with.
 	 */
 	config: {
-		get () {
-			let config = {
-				bindto: this.graphBaseElement,
-				data: {
-					columns: []
-				}
+		type: '*',
+		get (val = {}) {
+			let config = val;
+			config.bindto = this.graphBaseElement;
+			config.data = {
+				columns: []
 			};
-			if (this.axisXType){
+			if (val.axis && val.axis.x) {
 				config.data.x = 'x';
-				config.axis = {
-					x: {
-						type: this.axisXType
-					}
-				}
-			}
-			if (this.axis) {
-				config.data.x = 'x';
-				config.axis = this.axis;
 			}
 			return config;
 		}

--- a/src/viewmodel.js
+++ b/src/viewmodel.js
@@ -3,5 +3,37 @@ import DefineMap from "can-define/map/map";
 export default DefineMap.extend({
 	chart: {
 		value: null
-  }
+	},
+	/**
+	 * Dom element that chart will be bound to.
+	 */
+	graphBaseElement: {
+		type: '*'
+	},
+	/**
+	 * Config param for x-axis type.
+	 */
+	axisXType: 'string',
+	/**
+	 * Config object that c3 chart will be generated with.
+	 */
+	config: {
+		get () {
+			let config = {
+				bindto: this.graphBaseElement,
+				data: {
+					columns: []
+				}
+			};
+			if (this.axisXType){
+				config.data.x = 'x';
+				config.axis = {
+					x: {
+						type: this.axisXType
+					}
+				}
+			}
+			return config;
+		}
+	}
 });

--- a/src/viewmodel.js
+++ b/src/viewmodel.js
@@ -11,15 +11,15 @@ export default DefineMap.extend({
 		type: '*'
 	},
 	/**
+	 * Full config for axis.
+	 */
+	axis: {
+		type: '*'
+	},
+	/**
 	 * Config param for x-axis type.
 	 */
 	axisXType: 'string',
-	/**
-	 * Full config for x-axis.
-	 */
-	axisX: {
-		type: '*'
-	},
 	/**
 	 * Config object that c3 chart will be generated with.
 	 */
@@ -39,11 +39,9 @@ export default DefineMap.extend({
 					}
 				}
 			}
-			if (this.axisX) {
+			if (this.axis) {
 				config.data.x = 'x';
-				config.axis = {
-					x: this.axisX
-				};
+				config.axis = this.axis;
 			}
 			return config;
 		}

--- a/test/bit-c3_test.js
+++ b/test/bit-c3_test.js
@@ -24,26 +24,18 @@ var flattenCanList = function(list) {
 	return flatList;
 }
 
-QUnit.module('bit-c3 config');
+QUnit.module('bit-c3');
 
-test('Should configure x-axis using type', 1, (assert) => {
-	let tpl = '<bit-c3 axis-x-type="category"><bit-c3-data><bit-c3-data-column /></bit-c3-data></bit-c3>';
-	let frag = stache(tpl)({});
-	let vm = canViewModel(frag.querySelector('bit-c3'));
-	assert.deepEqual(vm.config, {data:{columns:[],x:'x'},axis:{x:{type:'category'}},bindto:undefined}, 'Config object is defined correctly');
-});
-
-test('Should configure axis using full config', 1, (assert) => {
-	let tpl = '<bit-c3 {axis}="axis"><bit-c3-data><bit-c3-data-column /></bit-c3-data></bit-c3>';
+test('Should configure chart using a passed config', 1, (assert) => {
+	let tpl = '<bit-c3 {config}="config"><bit-c3-data><bit-c3-data-column /></bit-c3-data></bit-c3>';
 	let frag = stache(tpl)({
-		axis: {
-			x: {
-				type: 'category',
-				tick: {
-					rotate: -45,
-					multiline: false
-				},
-				height: 130
+		config: {
+			axis: {
+				x: {
+					type: 'category',
+					tick: { rotate: -45, multiline: false },
+					height: 130
+				}
 			}
 		}
 	});

--- a/test/bit-c3_test.js
+++ b/test/bit-c3_test.js
@@ -12,6 +12,7 @@ import {randomString} from "bit-c3/lib/";
 import DefineList from "can-define/list/list";
 import DefineMap from "can-define/map/map";
 import stache from "can-stache";
+import canViewModel from "can-view-model";
 
 F.attach(QUnit);
 
@@ -23,9 +24,14 @@ var flattenCanList = function(list) {
 	return flatList;
 }
 
-QUnit.module('bit-c3');
+QUnit.module('bit-c3 config');
 
-// no tests currently
+test('Should configure x-axis', 1, (assert) => {
+	let tpl = '<bit-c3 axis-x-type="category"><bit-c3-data><bit-c3-data-column /></bit-c3-data></bit-c3>';
+	let frag = stache(tpl)({});
+	let vm = canViewModel(frag.querySelector('bit-c3'));
+	assert.deepEqual(vm.config, {data:{columns:[],x:'x'},axis:{x:{type:'category'}},bindto:undefined}, 'Config object is defined correctly');
+});
 
 QUnit.module('bit-c3-data');
 

--- a/test/bit-c3_test.js
+++ b/test/bit-c3_test.js
@@ -33,16 +33,18 @@ test('Should configure x-axis using type', 1, (assert) => {
 	assert.deepEqual(vm.config, {data:{columns:[],x:'x'},axis:{x:{type:'category'}},bindto:undefined}, 'Config object is defined correctly');
 });
 
-test('Should configure x-axis using full config', 1, (assert) => {
-	let tpl = '<bit-c3 {axis-x}="axisX"><bit-c3-data><bit-c3-data-column /></bit-c3-data></bit-c3>';
+test('Should configure axis using full config', 1, (assert) => {
+	let tpl = '<bit-c3 {axis}="axis"><bit-c3-data><bit-c3-data-column /></bit-c3-data></bit-c3>';
 	let frag = stache(tpl)({
-		axisX: {
-			type: 'category',
-			tick: {
-				rotate: -45,
-				multiline: false
-			},
-			height: 130
+		axis: {
+			x: {
+				type: 'category',
+				tick: {
+					rotate: -45,
+					multiline: false
+				},
+				height: 130
+			}
 		}
 	});
 	let vm = canViewModel(frag.querySelector('bit-c3'));

--- a/test/bit-c3_test.js
+++ b/test/bit-c3_test.js
@@ -26,11 +26,37 @@ var flattenCanList = function(list) {
 
 QUnit.module('bit-c3 config');
 
-test('Should configure x-axis', 1, (assert) => {
+test('Should configure x-axis using type', 1, (assert) => {
 	let tpl = '<bit-c3 axis-x-type="category"><bit-c3-data><bit-c3-data-column /></bit-c3-data></bit-c3>';
 	let frag = stache(tpl)({});
 	let vm = canViewModel(frag.querySelector('bit-c3'));
 	assert.deepEqual(vm.config, {data:{columns:[],x:'x'},axis:{x:{type:'category'}},bindto:undefined}, 'Config object is defined correctly');
+});
+
+test('Should configure x-axis using full config', 1, (assert) => {
+	let tpl = '<bit-c3 {axis-x}="axisX"><bit-c3-data><bit-c3-data-column /></bit-c3-data></bit-c3>';
+	let frag = stache(tpl)({
+		axisX: {
+			type: 'category',
+			tick: {
+				rotate: -45,
+				multiline: false
+			},
+			height: 130
+		}
+	});
+	let vm = canViewModel(frag.querySelector('bit-c3'));
+	assert.deepEqual(vm.config, {
+		data: { columns:[], x:'x' },
+		axis: {
+			x: {
+				type:'category',
+				tick: { rotate: -45, multiline: false },
+				height: 130
+			}
+		},
+		bindto: undefined
+	}, 'Config object is defined correctly');
 });
 
 QUnit.module('bit-c3-data');


### PR DESCRIPTION
Simply `bit-c3` to accept a config object which will be passed to c3 to generate chart.

Issues: #19, #23 

Config object:
```js
let config = {
  axis: {
    x: {
      type: 'category',
      tick: {
        rotate: -45,
        multiline: false
      },
      height: 130
    }
  }
};
let axisXData = new DefineList(['x','cat 1','cat 2','cat 3'])
```
Template:
```html
<bit-c3 {config}="config">
	<bit-c3-data type="{type}">
		{{#each dataColumns}}
			<bit-c3-data-column value="{.}" {axis-x}="axisXData" />
		{{/each}}
	</bit-c3-data>
</bit-c3>
```

Will generate barchart with x category labels rotated by `-45`:
![image](https://cloud.githubusercontent.com/assets/1895948/25934315/0347ef66-35eb-11e7-8e44-7206e3b73897.png)
