### PR TITLE
bugfix: do not use es6 default for a getter argument

### DIFF
--- a/src/viewmodel.js
+++ b/src/viewmodel.js
@@ -15,8 +15,8 @@ export default DefineMap.extend({
 	 */
 	config: {
 		type: '*',
-		get (val = {}) {
-			let config = val;
+		get (val) {
+			let config = val || {};
 			config.bindto = this.graphBaseElement;
 			if (!config.data){
 				config.data = {


### PR DESCRIPTION
```
get ( val = {} ) ...
```
gets translated into a get function without arguments which breaks the intended functionality of a getter.